### PR TITLE
Allow other autocommands to fire (eg DirChanged)

### DIFF
--- a/plugin/nvim-rooter.lua
+++ b/plugin/nvim-rooter.lua
@@ -9,6 +9,6 @@ vim.cmd([[
   augroup nvim_rooter
     autocmd!
     autocmd BufRead * lua vim.api.nvim_buf_set_var(0, 'root_dir', nil)
-    autocmd BufEnter * lua require'nvim-rooter'.rooter()
+    autocmd BufEnter * nested lua require'nvim-rooter'.rooter()
   augroup END
 ]])


### PR DESCRIPTION
Currently, the directory change that the plugin makes doesn't fire off the `DirChanged` autocommand, which is needed for other plugins (like direnv.vim) to work. This fixes that.